### PR TITLE
Fix glyphicons missing

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,4 +1,11 @@
 $bootstrap-sass-asset-helper: true;
+$icon-font-path: '../node_modules/bootstrap-sass/assets/fonts/bootstrap/';
+
+@function font-path($path) {
+  @return $path;
+}
+
+@import "../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap-sprockets.scss";
 @import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
 /* Main Style File */
 @import './style/_main';


### PR DESCRIPTION
Solution from here http://stackoverflow.com/questions/28148322/bootstrap-sass-relative-glyphicons-icon-path
![image](https://cloud.githubusercontent.com/assets/1658727/24216636/e1a272aa-0f34-11e7-8a2a-1ffd78020ab6.png)
